### PR TITLE
Convert service codes to array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 NEXT VERSION
 ========
 * Convert additional_service_codes inside carrier configurations from JSON string to array
+* Take additional service codes into account when displaying pickup selector and doing order validation operations
 
 20230403 v1.1.1
 ========

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 NEXT VERSION
 ========
+* Convert additional_service_codes inside carrier configurations from JSON string to array
 
 20230403 v1.1.1
 ========

--- a/src/Service/VgPostnordBookingService.php
+++ b/src/Service/VgPostnordBookingService.php
@@ -75,7 +75,7 @@ class VgPostnordBookingService
                 $mandatory_services = $carrier_settings[$carrier->id_reference]["mandatory_service_codes"] ?? [];
             }
             if (array_key_exists("additional_service_codes", $carrier_settings[$carrier->id_reference])) {
-                $additional_services = json_decode($carrier_settings[$carrier->id_reference]["additional_service_codes"]) ?? [];
+                $additional_services = $carrier_settings[$carrier->id_reference]["additional_service_codes"] ?? [];
             }
         }
         $additional_service_codes = implode(",", array_unique(array_merge($mandatory_services, $additional_services)));

--- a/upgrade/upgrade-1.1.2.php
+++ b/upgrade/upgrade-1.1.2.php
@@ -1,0 +1,22 @@
+<?php
+
+if (!defined("_PS_VERSION_")) {
+    exit;
+}
+
+/**
+ * @noinspection PhpUnused
+ */
+function upgrade_module_1_1_2(Vg_postnord $module): bool
+{
+    // convert additional_service_codes from JSON string to array in carrier config
+    $carrier_config = $module->getCarrierConfigurations();
+    foreach ($carrier_config as &$config) {
+        if (is_string($config["additional_service_codes"])) {
+            $asc = json_decode($config["additional_service_codes"]) ?? [];
+            $config["additional_service_codes"] = $asc;
+        }
+    }
+
+    return Configuration::updateValue('VG_POSTNORD_CARRIER_SETTINGS', json_encode($carrier_config));
+}

--- a/vg_postnord.php
+++ b/vg_postnord.php
@@ -780,6 +780,27 @@ class Vg_postnord extends CarrierModule
     }
 
     /**
+     * Get both mandatory and additional service codes for a given carrier config
+     *
+     * @param array $carrier_config
+     *
+     * @return array
+     */
+    public function getCombinedServiceCodesForConfig(array $carrier_config): array
+    {
+        $mandatory = $additional = [];
+
+        if (array_key_exists("additional_service_codes", $carrier_config)) {
+            $additional = $carrier_config["additional_service_codes"];
+        }
+        if (array_key_exists("mandatory_service_codes", $carrier_config)) {
+            $mandatory = $carrier_config["mandatory_service_codes"];
+        }
+
+        return array_unique(array_merge($mandatory, $additional));
+    }
+
+    /**
      * Save form data.
      */
     protected function postProcess(): bool

--- a/vg_postnord.php
+++ b/vg_postnord.php
@@ -940,9 +940,20 @@ class Vg_postnord extends CarrierModule
      */
     public function hookDisplayCarrierExtraContent($params)
     {
-        // don't show pickup point selection if "optional service point" isn't a mandatory additional service
+        // don't show pickup point selection if the "optional service point" additional service hasn't been
+        // selected and isn't mandatory
         $carrier_config = $this->getCarrierConfiguration((int) $params["carrier"]["id_reference"]);
-        if (!in_array("A7", $carrier_config["mandatory_service_codes"])) {
+        if (
+            !array_key_exists("additional_service_codes", $carrier_config)
+            || !array_key_exists("mandatory_service_codes", $carrier_config)
+        ) {
+            return null;
+        }
+        $additional_service_codes = json_decode($carrier_config["additional_service_codes"]) ?? [];
+        if (
+            !in_array("A7", $carrier_config["mandatory_service_codes"])
+            && !in_array("A7", $additional_service_codes)
+        ) {
             return null;
         }
 

--- a/vg_postnord.php
+++ b/vg_postnord.php
@@ -1156,8 +1156,8 @@ class Vg_postnord extends CarrierModule
     /**
      * Operations when an order is created:
      * - Save id_order in cart data if shipping method is PostNord
-     * - Clear service point from cart data if it's not required
-     * - Pre-select the 'closest' service point if the customer didn't select any (and is required)
+     * - Clear service point from cart data if it's not applicable
+     * - Pre-select the 'closest' service point if the customer didn't select any (and is applicable)
      * - Fetch and save service point data to cart data if it has a service point id
      */
     public function hookActionValidateOrder(array $params)

--- a/vg_postnord.php
+++ b/vg_postnord.php
@@ -972,17 +972,8 @@ class Vg_postnord extends CarrierModule
         // don't show pickup point selection if the "optional service point" additional service hasn't been
         // selected and isn't mandatory
         $carrier_config = $this->getCarrierConfiguration((int) $params["carrier"]["id_reference"]);
-        if (
-            !array_key_exists("additional_service_codes", $carrier_config)
-            || !array_key_exists("mandatory_service_codes", $carrier_config)
-        ) {
-            return null;
-        }
-        $additional_service_codes = json_decode($carrier_config["additional_service_codes"]) ?? [];
-        if (
-            !in_array("A7", $carrier_config["mandatory_service_codes"])
-            && !in_array("A7", $additional_service_codes)
-        ) {
+        $service_codes = $this->getCombinedServiceCodesForConfig($carrier_config);
+        if (!in_array("A7", $service_codes)) {
             return null;
         }
 
@@ -1236,22 +1227,8 @@ class Vg_postnord extends CarrierModule
         }
 
         $carrier_config = $this->getCarrierConfiguration($carrier->id_reference);
-        if (
-            !array_key_exists("additional_service_codes", $carrier_config)
-            || !array_key_exists("mandatory_service_codes", $carrier_config)
-        ) {
-            $this->logger->error("Service codes are missing from carrier configuration", [
-                "hook"     => "actionValidateOrder",
-                "id_order" => $order->id,
-                "id_cart"  => $cart->id
-            ]);
-            return;
-        }
-        $additional_service_codes = json_decode($carrier_config["additional_service_codes"]) ?? [];
-        if (
-            !in_array("A7", $carrier_config["mandatory_service_codes"])
-            && !in_array("A7", $additional_service_codes)
-        ) {
+        $service_codes = $this->getCombinedServiceCodesForConfig($carrier_config);
+        if (!in_array("A7", $service_codes)) {
             // have to make this check here and not right after fetching the cart data, since the else clause below
             // will have to create the data if it doesn't exist
             if (!$cartData) {

--- a/vg_postnord.php
+++ b/vg_postnord.php
@@ -750,10 +750,13 @@ class Vg_postnord extends CarrierModule
             // just for the label (free text). always empty data
             $carrierValues['id_carrier_reference_' . $carrier['id_reference']] = '';
 
-            $keys = ['service_code_consigneecountry', 'service_codes', 'additional_service_codes'];
+            $keys = ['service_code_consigneecountry', 'service_codes'];
             foreach ($keys as $key) {
                 $carrierValues['id_carrier_reference_' . $carrier['id_reference'] . '_' . $key] = $carrierSettings[$carrier['id_reference']][$key] ?? '';
             }
+
+            // special case: convert additional service codes into a JSON string for the hidden text input
+            $carrierValues['id_carrier_reference_' . $carrier['id_reference'] . '_additional_service_codes'] = json_encode($carrierSettings[$carrier['id_reference']]['additional_service_codes']) ?? '';
         }
 
         return $carrierValues;
@@ -843,6 +846,11 @@ class Vg_postnord extends CarrierModule
             } else {
                 $this->setCarrierToPostNord($id_carrier_reference, false);
             }
+
+            // convert additional_service_codes from JSON string to array for storage,
+            // so it won't be double-encoded inside the database
+            $asc = json_decode($oneconfig["additional_service_codes"]) ?? [];
+            $oneconfig["additional_service_codes"] = $asc;
 
             // TODO: swear there's a better way to do whatever the following lines do
 

--- a/vg_postnord.php
+++ b/vg_postnord.php
@@ -31,7 +31,7 @@ class Vg_postnord extends CarrierModule
     {
         $this->name = 'vg_postnord';
         $this->tab = 'shipping_logistics';
-        $this->version = '1.1.1';
+        $this->version = '1.1.2';
         $this->author = 'Vilkas Group Oy';
         $this->need_instance = 0;
 

--- a/vg_postnord.php
+++ b/vg_postnord.php
@@ -682,7 +682,7 @@ class Vg_postnord extends CarrierModule
 
         $carrier_selections = [];
 
-        // build setting fields for each carrier
+        // build setting fields for each carrier,
         // each carrier is prefixed with id_carrier_reference
         // and then their reference id
         // and then the setting
@@ -846,7 +846,7 @@ class Vg_postnord extends CarrierModule
 
             // TODO: swear there's a better way to do whatever the following lines do
 
-            if ($oneconfig["service_code_consigneecountry"] == false) {
+            if (!$oneconfig["service_code_consigneecountry"]) {
                 $oneconfig["mandatory_service_codes"] = [];
                 continue;
             }

--- a/vg_postnord.php
+++ b/vg_postnord.php
@@ -944,7 +944,7 @@ class Vg_postnord extends CarrierModule
      * If the selected carrier is marked as a postnord carrier that has pickup locations show a selection screen of
      * pickup point to the customer
      *
-     * The pickup point will be saved as a ajax request to be used for label creation later
+     * The pickup point will be saved as an ajax request to be used for label creation later
      */
     public function hookDisplayCarrierExtraContent($params)
     {

--- a/vg_postnord.php
+++ b/vg_postnord.php
@@ -1207,7 +1207,22 @@ class Vg_postnord extends CarrierModule
         }
 
         $carrier_config = $this->getCarrierConfiguration($carrier->id_reference);
-        if (!in_array("A7", $carrier_config["mandatory_service_codes"])) {
+        if (
+            !array_key_exists("additional_service_codes", $carrier_config)
+            || !array_key_exists("mandatory_service_codes", $carrier_config)
+        ) {
+            $this->logger->error("Service codes are missing from carrier configuration", [
+                "hook"     => "actionValidateOrder",
+                "id_order" => $order->id,
+                "id_cart"  => $cart->id
+            ]);
+            return;
+        }
+        $additional_service_codes = json_decode($carrier_config["additional_service_codes"]) ?? [];
+        if (
+            !in_array("A7", $carrier_config["mandatory_service_codes"])
+            && !in_array("A7", $additional_service_codes)
+        ) {
             // have to make this check here and not right after fetching the cart data, since the else clause below
             // will have to create the data if it doesn't exist
             if (!$cartData) {

--- a/views/js/config.js
+++ b/views/js/config.js
@@ -31,6 +31,7 @@ $(document).ready(() => {
         'service_code_consigneecountry'
       )}`
     );
+
     /**
      * Add checkbox in place of hiddenInput field with value from countryValidCombinations
      * filtered with serviceCodeField
@@ -65,19 +66,16 @@ $(document).ready(() => {
       Object.keys(filteredCombination)
         .sort()
         .forEach(function (element) {
-          checkboxesContent += `<div class="checkbox">
-                        <label for='${hiddenInput.id}_${
-  filteredCombination[element].adnlServiceCode
-}'>
-                        <input type="checkbox" name="checkbox" ${
-  hiddenInput.value.includes(element) ? 'checked' : ''
-}
-                        id="${hiddenInput.id}_${
-  filteredCombination[element].adnlServiceCode
-}" value="${filteredCombination[element].adnlServiceCode}">
-                        ${filteredCombination[element].adnlServiceCode} - ${filteredCombination[element].adnlServiceName}
-                    </label>
-                </div>`;
+          checkboxesContent += `
+            <div class="checkbox">
+              <label for='${hiddenInput.id}_${filteredCombination[element].adnlServiceCode}'>
+              <input type="checkbox" name="checkbox" ${hiddenInput.value.includes(element) ? 'checked' : ''}
+                     id="${hiddenInput.id}_${filteredCombination[element].adnlServiceCode}"
+                     value="${filteredCombination[element].adnlServiceCode}">
+                ${filteredCombination[element].adnlServiceCode} - ${filteredCombination[element].adnlServiceName}
+              </label>
+            </div>
+          `;
         });
 
       // Add checkboxes then click to update/clear hiddenInputField
@@ -88,7 +86,7 @@ $(document).ready(() => {
     $(hiddenInput).parent().prepend('<div class="checkboxes"></div>');
     addCheckbox(hiddenInput, serviceCodeField, countryValidCombinations);
 
-    // Loopthrough checkboxes on click and add value to the hiddenInput
+    // Loop through checkboxes on click and add value to the hiddenInput
     $(this)
       .parent()
       .click(function () {


### PR DESCRIPTION
* Convert additional_service_codes inside carrier configurations from JSON string to array
  * The format is now the same as mandatory_service_codes
  * Also added a function for getting both additional and mandatory services for a carrier at the same time
* Take additional service codes into account when displaying pickup selector and doing order validation operations
  * Both mandatory and additional services are now checked for the existence of the "A7" service code