### PR TITLE
Replace deprecated header hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ NEXT VERSION
 * Convert additional_service_codes inside carrier configurations from JSON string to array
 * Take additional service codes into account when displaying pickup selector and doing order validation operations
 * Remove old licenses from files
+* Use the "displayHeader" hook instead of the deprecated "header" hook
 
 20230403 v1.1.1
 ========

--- a/upgrade/upgrade-1.1.2.php
+++ b/upgrade/upgrade-1.1.2.php
@@ -18,5 +18,7 @@ function upgrade_module_1_1_2(Vg_postnord $module): bool
         }
     }
 
-    return Configuration::updateValue('VG_POSTNORD_CARRIER_SETTINGS', json_encode($carrier_config));
+    return Configuration::updateValue('VG_POSTNORD_CARRIER_SETTINGS', json_encode($carrier_config))
+        && $module->unregisterHook("header")
+        && $module->registerHook("displayHeader");
 }

--- a/vg_postnord.php
+++ b/vg_postnord.php
@@ -86,7 +86,7 @@ class Vg_postnord extends CarrierModule
 
         return parent::install()
             && $this->installSQL()
-            && $this->registerHook('header')
+            && $this->registerHook('displayHeader')
             && $this->registerHook('actionAdminControllerSetMedia')
             && $this->registerHook('displayCarrierExtraContent')
             && $this->registerHook('displayAdminOrderMain')
@@ -953,7 +953,7 @@ class Vg_postnord extends CarrierModule
     /**
      * Add the CSS & JavaScript files you want to be added on the FO.
      */
-    public function hookHeader()
+    public function hookDisplayHeader()
     {
         $this->context->controller->addJS($this->_path . '/views/js/front.js');
         $this->context->controller->addCSS($this->_path . '/views/css/front.css');


### PR DESCRIPTION
Fixes

> Deprecated: The hook "header" is deprecated, please use "displayHeader" instead in module "vg_postnord". in /var/www/html/classes/Hook.php on line 879

in PrestaShop 8.