### PR TITLE
Filter out service codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ NEXT VERSION
 * Use the "displayHeader" hook instead of the deprecated "header" hook
 * Move Party ID from address settings to basic settings
 * Check Party ID validity when saving module settings form
+* Filter out some service codes from being selectable:
+  - InNight (48)
+  - InNight Reverse (49)
+  - Retail Delivery (59)
+  - PostNord Part Loads (85)
+  - Domestic Road (99)
+* Fix a bug where an error would be displayed when saving carrier settings if the save handler couldn't find any
+  valid service code / country combinations
 
 20230403 v1.1.1
 ========

--- a/src/Client/PostnordClient.php
+++ b/src/Client/PostnordClient.php
@@ -265,6 +265,22 @@ class PostnordClient
             throw $e;
         }
 
+        /*
+         * Filter out some service codes from the response:
+         * - InNight (48)
+         * - InNight Reverse (49)
+         * - Retail Delivery (59)
+         * - PostNord Part Loads (85)
+         * - Domestic Road (99)
+         */
+        $filtered_service_codes = ["48", "49", "59", "85", "99"];
+        foreach ($response["data"] as &$datum) {
+            $datum["serviceCodeDetails"] = array_filter($datum["serviceCodeDetails"], function($element) use ($filtered_service_codes) {
+                return !in_array($element["serviceCode"], $filtered_service_codes);
+            });
+        }
+        unset($datum);
+
         return $response;
     }
 

--- a/vg_postnord.php
+++ b/vg_postnord.php
@@ -895,6 +895,11 @@ class Vg_postnord extends CarrierModule
             $valid_country_combinations = array_filter($valid_combinations, function ($element) use ($consignee_country) {
                 return $element['issuerCountryCode'] === $consignee_country ? $element : null;
             });
+            if (empty($valid_country_combinations)) {
+                $oneconfig["mandatory_service_codes"] = [];
+                continue;
+            }
+
             // find mandatory services for service code and consignee country
             $valid_country_combinations = reset($valid_country_combinations)["adnlServiceCodeCombDetails"];
             $mandatory_combinations = array_filter($valid_country_combinations, function ($element) use ($service_code, $consignee_country) {


### PR DESCRIPTION
* Filter out some service codes from being selectable:
  - InNight (48)
  - InNight Reverse (49)
  - Retail Delivery (59)
  - PostNord Part Loads (85)
  - Domestic Road (99)
* Fix a bug where an error would be displayed when saving carrier settings if the save handler couldn't find any
  valid service code / country combinations