### PR TITLE
Release v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 NEXT VERSION
 ========
+
+20230627 v1.1.2
+========
 * Convert additional_service_codes inside carrier configurations from JSON string to array
 * Take additional service codes into account when displaying pickup selector and doing order validation operations
 * Remove old licenses from files


### PR DESCRIPTION
* Convert additional_service_codes inside carrier configurations from JSON string to array
* Take additional service codes into account when displaying pickup selector and doing order validation operations
* Remove old licenses from files
* Use the "displayHeader" hook instead of the deprecated "header" hook
* Move Party ID from address settings to basic settings
* Check Party ID validity when saving module settings form
* Filter out some service codes from being selectable:
  - InNight (48)
  - InNight Reverse (49)
  - Retail Delivery (59)
  - PostNord Part Loads (85)
  - Domestic Road (99)
* Fix a bug where an error would be displayed when saving carrier settings if the save handler couldn't find any
  valid service code / country combinations
* Filter out outdoor lockers if 'M7' additional service (Not to outdoor parcel locker) is selected
* Check that the order is a PostNord order before trying to fetch label using ajax