### PR TITLE
Bump ruby version to 3.2 in docs/

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1' # Not needed with a .ruby-version file
+          ruby-version: '3.2' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
 


### PR DESCRIPTION
The addressable version bump (https://github.com/vilkasgroup/vg_postnord/pull/50) raised the minimum Ruby version to 3.2, and now builds are failing because of it. Let's see if this fixes it or if it breaks another dependency in the process!